### PR TITLE
Add ability to invalidate cloudfront cache on sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_CF_DISTRIBUTION_ID: ${{ secrets.AWS_CF_DISTRIBUTION_ID }} # optional: use only when configuring S3 + Cloudfront
         AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'public'      # optional: defaults to entire repository
 ```
@@ -54,6 +55,7 @@ The following settings must be passed as environment variables as shown in the e
 | `AWS_S3_BUCKET` | The name of the bucket you're syncing to. For example, `jarv.is` or `my-app-releases`. | `secret env` | **Yes** | N/A |
 | `AWS_REGION` | The region where you created your bucket. Set to `us-east-1` by default. [Full list of regions here.](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions) | `env` | No | `us-east-1` |
 | `AWS_S3_ENDPOINT` | The endpoint URL of the bucket you're syncing to. Can be used for [VPC scenarios](https://aws.amazon.com/blogs/aws/new-vpc-endpoint-for-amazon-s3/) or for non-AWS services using the S3 API, like [DigitalOcean Spaces](https://www.digitalocean.com/community/tools/adapting-an-existing-aws-s3-application-to-digitalocean-spaces). | `env` | No | Automatic (`s3.amazonaws.com` or AWS's region-specific equivalent) |
+| `AWS_CF_DISTRIBUTION_ID` | A CloudFront distribution ID, for which an invalidation will be created after syncing | `secret env` | No | N/A |
 | `SOURCE_DIR` | The local directory (or file) you wish to sync/upload to S3. For example, `public`. Defaults to your entire repository. | `env` | No | `./` (root of cloned repository) |
 | `DEST_DIR` | The directory inside of the S3 bucket you wish to sync/upload to. For example, `my_project/assets`. Defaults to the root of the bucket. | `env` | No | `/` (root of bucket) |
 

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,15 @@
 name: "S3 Sync"
 description: "Sync a directory to an AWS S3 repository"
 author: jakejarvis
+inputs:
+  args:
+    description: 'Additional arguments for s3 sync'
+    required: false
 runs:
   using: docker
   image: Dockerfile
+  args:
+    - ${{ inputs.args }}
 branding:
   icon: refresh-cw
   color: green

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,6 +44,11 @@ sh -c "aws s3 sync ${SOURCE_DIR:-.} s3://${AWS_S3_BUCKET}/${DEST_DIR} \
               --no-progress \
               ${ENDPOINT_APPEND} $*"
 
+# If a AWS_CF_DISTRIBUTION_ID was given, create an invalidation for it.
+if [ -n "$AWS_CF_DISTRIBUTION_ID" ]; then
+  sh -c "aws cloudfront create-invalidation --distribution-id ${AWS_CF_DISTRIBUTION_ID} --paths '/*' --profile s3-sync-action"
+fi
+
 # Clear out credentials after we're done.
 # We need to re-run `aws configure` with bogus input instead of
 # deleting ~/.aws in case there are other credentials living there.


### PR DESCRIPTION
- Invalidate cache: https://github.com/jakejarvis/s3-sync-action/pull/32
- Update arguments to clear warnings: https://github.com/jakejarvis/s3-sync-action/pull/34/files

Currently the files are syncing correctly but cloudfront is caching the `index.html` which is causing users to download the old `.js` files. This will allow us to invalidate the cache if we provide a Cloud Front distribution Id