### PR TITLE
PE-2319: Switch to upstream gitleaks with custom rules file

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+title = "Inscribe Rules"
+
+# Extend the base (this) configuration. When you extend a configuration
+# the base rules take precendence over the extended rules. I.e, if there are
+# duplicate rules in both the base configuration and the extended configuration
+# the base rules will override the extended rules.
+# Another thing to know with extending configurations is you can chain together
+# multiple configuration files to a depth of 2. Allowlist arrays are appended
+# and can contain duplicates.
+# useDefault and path can NOT be used at the same time. Choose one.
+[extend]
+# useDefault will extend the base configuration with the default gitleaks config:
+# https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+[[rules]]
+id = "inscribe-api-key"
+description = "Inscribe API Key"
+regex = '''INSK(P|D|T|S)_[a-zA-Z1-9+\/=]*'''
+tags = ["key", "Inscribe"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
--   repo: git@github.com:InscribeAI/gitleaks.git
-    rev: 83a7b4551b262d65d53b38dd0b1926cb5bdd544d
+-   repo: git@github.com:zricethezav/gitleaks.git
+    rev: v8.15.0
     hooks:
     -   id: gitleaks


### PR DESCRIPTION
## Basic Description

Switch from our Gitleaks fork back to the official Gitleaks (zricethezav). Gitleaks now supports a custom rules file which can extend the built-in rules. There is therefore no longer any need for us to maintain our own fork in order to add custom rules. Additionally, this has the benefit of being able to use the latest Gitleaks which fixes a bug with Gitleaks running on an M1 Mac.

## Extra context

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change, such as our public API)

## Quality Control

<!---

STEP 4: Have you tested important functionality?

        Done? Make sure you have filled out all sections required from Step three.

--->
### Think about your code. Add tests to ensure it doesn't:
- [x] leak customer information (Confidentiality),
- [ ] allow people alter things they don't have permission to (Integrity),
- [ ] lead to the app going down (Availability),
- [ ] I have thought about it, and my code does not impact the above and thus doesn't require new tests.

Note: technically, this changes the tests to ensure we don't leak secrets so I have ticked the confidentiality box above although no tests have been added to ensure that these tests do indeed work. However, I have manually verified that the changes will extend the base rules by detecting Inscribe API Keys as well as a secret from the default ruleset, like an AWS key.
<!---

STEP 5: Have you ensured you followed Inscribe's security requirements?

        Done? Make sure you have filled out all sections required from Step three.
        If you have, go to Step 6.

--->
###  Think about your code. Ensure it does the following:
- [ ] verifies a person is authenticated (logged in) before using your code,
- [ ] verifies a person is authorised to carry out an action,
- [ ] writes a log message at `info` level detailing what the user did, so we can audit their actions if we find a bug.
- [x] I have thought about it, and my code does not require these checks.


<!---

STEP 6: Would you like to add any screenshots? They can go here.

        Done? Publish your PR!

--->
#### Screenshots:
