### PR TITLE
Pin Alpine to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8-alpine3.19
 
 LABEL "com.github.actions.name"="S3 Sync"
 LABEL "com.github.actions.description"="Sync a directory to an AWS S3 repository"


### PR DESCRIPTION
The base image got bumped to `Alpine 3.20.0`, released ~18 hours ago.
This does not contain `aws-cli`:

![image](https://github.com/InscribeAI/s3-sync-action/assets/20187768/629e4956-89d6-480f-89e7-3c214c5f3ce0) 
Release notes [here](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.20.0), upstream issue [here](https://github.com/aws/aws-cli/issues/8342).



Will revisit this once it gets fixed.