### PR TITLE
Revert "Pin Alpine to 3.19"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.19
+FROM python:3.8-alpine
 
 LABEL "com.github.actions.name"="S3 Sync"
 LABEL "com.github.actions.description"="Sync a directory to an AWS S3 repository"


### PR DESCRIPTION
Reverts InscribeAI/s3-sync-action#3

`aws-cli` has been readded to the Alpine 3.20.x repo:

<img width="1069" alt="image" src="https://github.com/InscribeAI/s3-sync-action/assets/20187768/3a69ed02-5ddd-4129-82db-9fc51e3f1ccd">


```
/ # grep -i version /etc/os-release
VERSION_ID=3.20.0
/ # apk add -q aws-cli
/ # aws --version
aws-cli/2.15.57 Python/3.12.3 Linux/6.6.22-linuxkit source/aarch64.alpine.3
```